### PR TITLE
Extract users to separate model. Allow to pass user id type so it can…

### DIFF
--- a/src/BioEngine.Extra.IPB/Auth/IPBCurrentUserProvider.cs
+++ b/src/BioEngine.Extra.IPB/Auth/IPBCurrentUserProvider.cs
@@ -2,13 +2,13 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Security.Claims;
 using System.Threading.Tasks;
-using BioEngine.Core.Abstractions;
+using BioEngine.Core.Users;
 using BioEngine.Extra.IPB.Models;
 using Microsoft.AspNetCore.Http;
 
 namespace BioEngine.Extra.IPB.Auth
 {
-    public abstract class IPBCurrentUserProvider : ICurrentUserProvider
+    public abstract class IPBCurrentUserProvider : ICurrentUserProvider<string>
     {
         protected readonly IHttpContextAccessor HttpContextAccessor;
 
@@ -17,7 +17,7 @@ namespace BioEngine.Extra.IPB.Auth
             HttpContextAccessor = httpContextAccessor;
         }
 
-        public IUser CurrentUser
+        public IUser<string> CurrentUser
         {
             get
             {

--- a/src/BioEngine.Extra.IPB/Auth/User.cs
+++ b/src/BioEngine.Extra.IPB/Auth/User.cs
@@ -1,13 +1,13 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
-using BioEngine.Core.Abstractions;
 using BioEngine.Core.DB;
+using BioEngine.Core.Users;
 using BioEngine.Extra.IPB.Models;
 
 namespace BioEngine.Extra.IPB.Auth
 {
     [Entity("ipbuser")]
-    public class User : IUser
+    public class User : IUser<string>
     {
         public string Id { get; set; }
         public string Name { get; set; } = "";

--- a/src/BioEngine.Extra.IPB/BioEngine.Extra.IPB.csproj
+++ b/src/BioEngine.Extra.IPB/BioEngine.Extra.IPB.csproj
@@ -15,8 +15,10 @@
     <PackageReference Include="BioEngine.Core.Api" Version="3.0.*" Condition="!Exists('..\..\..\BioEngine.Core')" />
     <PackageReference Include="BioEngine.Core.Social" Version="3.0.*" Condition="!Exists('..\..\..\BioEngine.Core')" />
     <PackageReference Include="BioEngine.Core.Comments" Version="3.0.*" Condition="!Exists('..\..\..\BioEngine.Core')" />
+    <PackageReference Include="BioEngine.Core.Users" Version="3.0.*" Condition="!Exists('..\..\..\BioEngine.Core')" />
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\..\..\BioEngine.Core\src\BioEngine.Core.Users\BioEngine.Core.Users.csproj"  Condition="Exists('..\..\..\BioEngine.Core')" />
     <ProjectReference Include="..\..\..\BioEngine.Core\src\BioEngine.Core\BioEngine.Core.csproj" Condition="Exists('..\..\..\BioEngine.Core')" />
     <ProjectReference Include="..\..\..\BioEngine.Core\src\BioEngine.Core.Api\BioEngine.Core.Api.csproj" Condition="Exists('..\..\..\BioEngine.Core')" />
     <ProjectReference Include="..\..\..\BioEngine.Core\src\BioEngine.Core.Social\BioEngine.Core.Social.csproj" Condition="Exists('..\..\..\BioEngine.Core')" />

--- a/src/BioEngine.Extra.IPB/Comments/IPBCommentsSynchronizer.cs
+++ b/src/BioEngine.Extra.IPB/Comments/IPBCommentsSynchronizer.cs
@@ -165,6 +165,7 @@ namespace BioEngine.Extra.IPB.Comments
 
                 var comment = existingPosts.FirstOrDefault(p => p.PostId == post.Id) ?? new IPBComment
                 {
+                    ContentType = record.Type,
                     ContentId = record.ContentId,
                     AuthorId = post.Author?.Id ?? "0",
                     PostId = post.Id,

--- a/src/BioEngine.Extra.IPB/Controllers/ForumsController.cs
+++ b/src/BioEngine.Extra.IPB/Controllers/ForumsController.cs
@@ -2,6 +2,7 @@
 using System.Linq;
 using System.Threading.Tasks;
 using BioEngine.Core.Api.Response;
+using BioEngine.Core.Users;
 using BioEngine.Core.Web;
 using BioEngine.Extra.IPB.Api;
 using BioEngine.Extra.IPB.Models;
@@ -11,7 +12,8 @@ namespace BioEngine.Extra.IPB.Controllers
 {
     public class ForumsController : IPBController
     {
-        public ForumsController(BaseControllerContext context, IPBApiClientFactory factory) : base(context, factory)
+        public ForumsController(BaseControllerContext context, IPBApiClientFactory factory,
+            ICurrentUserProvider<string> currentUserProvider) : base(context, factory, currentUserProvider)
         {
         }
 

--- a/src/BioEngine.Extra.IPB/Controllers/IPBController.cs
+++ b/src/BioEngine.Extra.IPB/Controllers/IPBController.cs
@@ -1,4 +1,5 @@
 ﻿using System.Threading.Tasks;
+using BioEngine.Core.Users;
 using BioEngine.Core.Web;
 using BioEngine.Extra.IPB.Api;
 using Microsoft.AspNetCore.Authorization;
@@ -12,15 +13,18 @@ namespace BioEngine.Extra.IPB.Controllers
     public abstract class IPBController : BaseController
     {
         private readonly IPBApiClientFactory _factory;
+        private readonly ICurrentUserProvider<string> _currentUserProvider;
 
-        protected IPBController(BaseControllerContext context, IPBApiClientFactory factory) : base(context)
+        protected IPBController(BaseControllerContext context, IPBApiClientFactory factory,
+            ICurrentUserProvider<string> currentUserProvider) : base(context)
         {
             _factory = factory;
+            _currentUserProvider = currentUserProvider;
         }
 
         protected async Task<IPBApiClient> GetClientAsync()
         {
-            return _factory.GetClient(await CurrentToken);
+            return _factory.GetClient(await _currentUserProvider.GetAccessTokenAsync());
         }
 
         protected IPBApiClient ReadOnlyClient => _factory.GetReadOnlyClient();

--- a/src/BioEngine.Extra.IPB/Entities/IPBComment.cs
+++ b/src/BioEngine.Extra.IPB/Entities/IPBComment.cs
@@ -6,7 +6,7 @@ namespace BioEngine.Extra.IPB.Entities
 {
 #pragma warning disable CS8618 // Non-nullable field is uninitialized.
     [Entity("ipbcomments")]
-    public class IPBComment : BaseComment
+    public class IPBComment : BaseComment<string>
     {
         [Required] public int PostId { get; set; }
         [Required] public int TopicId { get; set; }

--- a/src/BioEngine.Extra.IPB/IPBModule.cs
+++ b/src/BioEngine.Extra.IPB/IPBModule.cs
@@ -1,13 +1,18 @@
 using System;
+using BioEngine.Core.DB;
 using BioEngine.Core.Entities;
 using BioEngine.Core.Modules;
 using BioEngine.Core.Properties;
 using BioEngine.Extra.IPB.Api;
 using BioEngine.Extra.IPB.Comments;
+using BioEngine.Extra.IPB.Entities;
 using BioEngine.Extra.IPB.Properties;
+using BioEngine.Extra.IPB.Publishing;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
 
 namespace BioEngine.Extra.IPB
 {
@@ -45,5 +50,13 @@ namespace BioEngine.Extra.IPB
         public Uri ApiUrl => new Uri($"{Url!}/api");
         public string ApiReadonlyKey { get; set; } = "";
         public string ApiPublishKey { get; set; } = "";
+    }
+    
+    public class IpbBioContextConfigurator: IBioContextModelConfigurator{
+        public void Configure(ModelBuilder modelBuilder, ILogger<BioContext> logger)
+        {
+            modelBuilder.RegisterEntity<IPBPublishRecord>();
+            modelBuilder.RegisterEntity<IPBComment>();
+        }
     }
 }

--- a/src/BioEngine.Extra.IPB/IPBSiteModule.cs
+++ b/src/BioEngine.Extra.IPB/IPBSiteModule.cs
@@ -13,7 +13,7 @@ namespace BioEngine.Extra.IPB
             IHostEnvironment environment)
         {
             base.ConfigureServices(services, configuration, environment);
-            services.AddScoped<ICommentsProvider, IPBCommentsProvider>();
+            services.AddScoped<ICommentsProvider<string>, IPBCommentsProvider>();
         }
     }
 

--- a/src/BioEngine.Extra.IPB/IPBUsersModule.cs
+++ b/src/BioEngine.Extra.IPB/IPBUsersModule.cs
@@ -1,6 +1,4 @@
-using BioEngine.Core.Abstractions;
 using BioEngine.Core.Users;
-using BioEngine.Extra.IPB.Auth;
 using BioEngine.Extra.IPB.Users;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -9,9 +7,9 @@ using Microsoft.Extensions.Hosting;
 namespace BioEngine.Extra.IPB
 {
     public abstract class
-        IPBUsersModule<TConfig, TCurrentUserProvider> : BaseUsersModule<TConfig, User,
+        IPBUsersModule<TConfig, TCurrentUserProvider> : BaseUsersModule<TConfig, string,
             IPBUserDataProvider, TCurrentUserProvider> where TConfig : IPBUsersModuleConfig
-        where TCurrentUserProvider : class, ICurrentUserProvider
+        where TCurrentUserProvider : class, ICurrentUserProvider<string>
     {
         public override void ConfigureServices(IServiceCollection services, IConfiguration configuration,
             IHostEnvironment environment)

--- a/src/BioEngine.Extra.IPB/Properties/IPBSitePropertiesSet.cs
+++ b/src/BioEngine.Extra.IPB/Properties/IPBSitePropertiesSet.cs
@@ -1,8 +1,8 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
-using BioEngine.Core.Abstractions;
 using BioEngine.Core.Properties;
+using BioEngine.Core.Users;
 using BioEngine.Extra.IPB.Api;
 using BioEngine.Extra.IPB.Models;
 using JetBrains.Annotations;
@@ -23,11 +23,11 @@ namespace BioEngine.Extra.IPB.Properties
     public class IPBSectionPropertiesOptionsResolver : IPropertiesOptionsResolver
     {
         private readonly IPBApiClientFactory _apiClientFactory;
-        private readonly ICurrentUserProvider _currentUserProvider;
+        private readonly ICurrentUserProvider<string> _currentUserProvider;
         private IPBApiClient _apiClient;
 
         public IPBSectionPropertiesOptionsResolver(IPBApiClientFactory apiClientFactory,
-            ICurrentUserProvider currentUserProvider)
+            ICurrentUserProvider<string> currentUserProvider)
         {
             _apiClientFactory = apiClientFactory;
             _currentUserProvider = currentUserProvider;

--- a/src/BioEngine.Extra.IPB/Publishing/IPBContentPublisher.cs
+++ b/src/BioEngine.Extra.IPB/Publishing/IPBContentPublisher.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Threading.Tasks;
+using BioEngine.Core.Abstractions;
 using BioEngine.Core.DB;
 using BioEngine.Core.Entities;
 using BioEngine.Core.Social;
@@ -16,14 +17,14 @@ namespace BioEngine.Extra.IPB.Publishing
         private readonly IContentRender _contentRender;
 
         public IPBContentPublisher(IPBApiClientFactory apiClientFactory, IContentRender contentRender,
-            BioContext dbContext, BioEntitiesManager entitiesManager,
-            ILogger<IPBContentPublisher> logger) : base(dbContext, logger, entitiesManager)
+            BioContext dbContext,
+            ILogger<IPBContentPublisher> logger) : base(dbContext, logger)
         {
             _apiClientFactory = apiClientFactory;
             _contentRender = contentRender;
         }
 
-        protected override async Task<IPBPublishRecord> DoPublishAsync(IPBPublishRecord record, ContentItem entity,
+        protected override async Task<IPBPublishRecord> DoPublishAsync(IPBPublishRecord record, IContentItem entity,
             Site site,
             IPBPublishConfig config)
         {
@@ -39,7 +40,7 @@ namespace BioEngine.Extra.IPB.Publishing
             return result.Hidden;
         }
 
-        private async Task<IPBPublishRecord> CreateOrUpdateContentPostAsync(IPBPublishRecord record, ContentItem item,
+        private async Task<IPBPublishRecord> CreateOrUpdateContentPostAsync(IPBPublishRecord record, IContentItem item,
             Site site,
             IPBPublishConfig config)
         {
@@ -58,7 +59,7 @@ namespace BioEngine.Extra.IPB.Publishing
                     Title = item.Title,
                     Hidden = !item.IsPublished ? 1 : 0,
                     Post = await _contentRender.RenderHtmlAsync(item, site),
-                    Author = int.Parse(item.AuthorId)
+                    Author = int.Parse(config.AuthorId)
                 };
                 var createdTopic = await apiClient.PostAsync<TopicCreateModel, Topic>("forums/topics", topic);
                 if (createdTopic.FirstPost != null)
@@ -75,7 +76,7 @@ namespace BioEngine.Extra.IPB.Publishing
                     {
                         Title = item.Title,
                         Hidden = !item.IsPublished ? 1 : 0,
-                        Author = int.Parse(item.AuthorId),
+                        Author = int.Parse(config.AuthorId),
                         Forum = config.ForumId,
                         Post = await _contentRender.RenderHtmlAsync(item, site)
                     });

--- a/src/BioEngine.Extra.IPB/Publishing/IPBPublishConfig.cs
+++ b/src/BioEngine.Extra.IPB/Publishing/IPBPublishConfig.cs
@@ -4,11 +4,13 @@ namespace BioEngine.Extra.IPB.Publishing
 {
     public class IPBPublishConfig : IContentPublisherConfig
     {
-        public IPBPublishConfig(int forumId)
+        public IPBPublishConfig(int forumId, string authorId)
         {
             ForumId = forumId;
+            AuthorId = authorId;
         }
 
         public int ForumId { get; }
+        public string AuthorId { get; }
     }
 }

--- a/src/BioEngine.Extra.IPB/Users/IPBUserDataProvider.cs
+++ b/src/BioEngine.Extra.IPB/Users/IPBUserDataProvider.cs
@@ -1,14 +1,14 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
-using BioEngine.Core.Abstractions;
+using BioEngine.Core.Users;
 using BioEngine.Extra.IPB.Api;
 using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Logging;
 
 namespace BioEngine.Extra.IPB.Users
 {
-    public class IPBUserDataProvider : IUserDataProvider
+    public class IPBUserDataProvider : IUserDataProvider<string>
     {
         private readonly IPBApiClientFactory _clientFactory;
         private readonly IMemoryCache _memoryCache;
@@ -27,14 +27,14 @@ namespace BioEngine.Extra.IPB.Users
             return $"ipbuserdata{userId}";
         }
 
-        private List<IUser> GetFromCache(IEnumerable<string> userIds)
+        private List<IUser<string>> GetFromCache(IEnumerable<string> userIds)
         {
             _logger.LogTrace("Get user data from cache");
-            return userIds.Select(GetCacheKey).Select(key => _memoryCache.Get<IUser>(key))
+            return userIds.Select(GetCacheKey).Select(key => _memoryCache.Get<IUser<string>>(key))
                 .Where(userData => userData != null).ToList();
         }
 
-        public async Task<List<IUser>> GetDataAsync(string[] userIds)
+        public async Task<List<IUser<string>>> GetDataAsync(string[] userIds)
         {
             var data = GetFromCache(userIds);
             var notFoundUserIds = userIds
@@ -52,7 +52,7 @@ namespace BioEngine.Extra.IPB.Users
             return data;
         }
 
-        private void SetToCache(IEnumerable<IUser> userData)
+        private void SetToCache(IEnumerable<IUser<string>> userData)
         {
             _logger.LogTrace("Set user data to cache");
             foreach (var data in userData)


### PR DESCRIPTION
… be defined on application level, not hardcoded as string. Separate content items. Don't use single table for them.

Update to .NET Core 3.0